### PR TITLE
Add in-code documentation and update examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,15 +9,12 @@ interact with the resources in Tempest.
 
 ### Usage
 
-1. Navigate to the directory where the OpenTofu module is found. In the example
-   code this would be `apps/opentofu/v1/module`.
-2. Run `OPENTOFU_WORKDIR=$(pwd) tempest app <command> opentofu:v1`
+1. Run the app with the CLI from with the `examples/` directory.
 
 ### Example
 
 ```shell
-$ cd apps/opentofu/v1/module
-$ OPENTOFU_WORKDIR=$(pwd) tempest app describe opentofu:v1
+$ tempest app describe opentofu:v1
 
 Tempest App Description
 -----------------------
@@ -29,14 +26,14 @@ Resource Type: S3 Bucket
 
 Operations Supported:
 - ✅ Read
-- ✅ List
+- ❌ List
 - ✅ Create
 - ✅ Update
 - ✅ Delete
 
 Health Check Supported: ✅
 
-$ OPENTOFU_WORKDIR=$(pwd) tempest app test opentofu:v1 --operation create --type s3_bucket --input '{"name":"my-test-bucket"}'
+$ tempest app test opentofu:v1 --operation create --type s3_bucket --input '{"name":"my-test-bucket"}' --env SECRET_KEY=abcd123 --env ACCESS_KEY=12345
 
 Resource created with ID:  arn:aws:s3:::my-test-bucket
 Properties:

--- a/apps/helloworld/v1/app.go
+++ b/apps/helloworld/v1/app.go
@@ -234,8 +234,8 @@ func App() *app.App {
 	exampleDef.CreateFn(
 		// The function handler that will be run when the Create operation is called.
 		createFn,
-		// The schema that defines the input for the Create operation. This schema is empty, but can be extended to suit your needs.
-		app.MustParseJSONSchema(app.GenericEmptySchema),
+		// The schema that defines the input for the Create operation.
+		app.MustParseJSONSchema(input),
 	)
 
 	// Update is called when Tempest is instructed to update an existing resource in the external system.
@@ -247,8 +247,8 @@ func App() *app.App {
 	exampleDef.UpdateFn(
 		// The function handler that will be run when the Update operation is called.
 		updateFn,
-		// The schema that defines the input for the Update operation. This schema is empty, but can be extended to suit your needs.
-		app.MustParseJSONSchema(app.GenericEmptySchema),
+		// The schema that defines the input for the Update operation.
+		app.MustParseJSONSchema(input),
 	)
 
 	// Read and Delete functions are also assigned to the resource definition.

--- a/apps/helloworld/v1/app.go
+++ b/apps/helloworld/v1/app.go
@@ -1,0 +1,281 @@
+package helloworld
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/tempestdx/sdk-go/app"
+)
+
+// The create function should perform the operations necessary to create the resource in the external system.
+// This could be the result of multiple API calls, execution of a script, or any other operation.
+// In this example, we are simply returning a new resource with a generated ExternalID.
+//
+// Check the "dashboards" and "opentofu" examples for more complex examples.
+// https://github.com/tempestdx/examples
+func createFn(ctx context.Context, req *app.OperationRequest) (*app.OperationResponse, error) {
+	// The incoming request will contain the input values that the user has provided,
+	// the environment variables and secrets that are configured for the Project, as well as Metadata about the Project.
+
+	// ... perform some operation to create the resource with the specified color in the external system ...
+	// id, err := client.Create(ctx, req.Input["color"])
+
+	color := req.Input["color"]
+	id := strconv.Itoa(int(time.Now().Unix()))
+
+	// Construct the OperationResponse which contains the Resource that was created.
+	// Tempest will store these values in the Resource and relate it to the Project that created it.
+	return &app.OperationResponse{
+		Resource: &app.Resource{
+			// The ExternalID is the unique identifier for the resource in the external system.
+			// In AWS, this may be the ARN. A GitHub repo would be identified by the owner and repo name (org/repo).
+			ExternalID: id,
+			// DisplayName is the name of the resource that will be displayed in the Tempest UI.
+			DisplayName: fmt.Sprintf("Example Resource - %s", color),
+			// These properties should match what is defined in the `properties.json` schema.
+			Properties: map[string]any{
+				"color": color,
+			},
+			// Links is a list of links that will be displayed in the UI.
+			// There are different types of links that can be displayed:
+			// - External: The link to view the resource in the external system.
+			// - Support: The link to the support page for the individual resource.
+			// - Endpoint: The link to the endpoint of the resource. For example, the connection string for a database.
+			// - Documentation: The link to the documentation for the resource.
+			// - Administration: The link to the administration page for the resource.
+			Links: []*app.Link{
+				{
+					URL:   fmt.Sprintf("https://example.com/resource/%s", id),
+					Title: "Example.com Resource Console",
+					Type:  app.LinkTypeExternal,
+				},
+			},
+		},
+	}, nil
+}
+
+// The update function should perform the operations necessary to update the resource in the external system.
+// In this example, we are simply returning the same resource with a new DisplayName.
+func updateFn(ctx context.Context, req *app.OperationRequest) (*app.OperationResponse, error) {
+	// The incoming request will contain the input values that the user has provided,
+	// the environment variables and secrets that are configured for the Project, as well as Metadata about the Project.
+	//
+	// For an Update operation, the req.Resource object will also be populated with the current state of the resource in Tempest.
+	// This includes the ExternalID, DisplayName, and Properties.
+
+	// ... perform some operation to update the resource's color in the external system ...
+	// newColor, err := client.Update(ctx, req.Resource.ExternalID, req.Input["color"])
+	newColor := req.Input["color"]
+
+	// Construct the updated Resource and wrap it in an OperationResponse.
+	// Tempest will update the values of the Resource according to the values returned here.
+	return &app.OperationResponse{
+		Resource: &app.Resource{
+			// Fields that aren't changing (such as the ExternalID) can be omitted.
+			DisplayName: fmt.Sprintf("Example Resource - %s", newColor),
+			Properties: map[string]any{
+				"color": newColor,
+			},
+		},
+	}, nil
+}
+
+// The read function should perform the operations necessary to gather the current state of the resource in the external system.
+func readFn(ctx context.Context, req *app.OperationRequest) (*app.OperationResponse, error) {
+	// The incoming request will contain the ExternalID of the resource that needs to be retrieved in the req.Resource object,
+	// the environment variables and secrets that are configured for the Project, as well as Metadata about the Project.
+
+	// ... perform some operation to read the resource and its color from the external system ...
+	// color, err := client.Get(ctx, req.Resource.ExternalID)
+	color := "blue"
+
+	// Construct the OperationResponse which contains the Resource that was read.
+	// Tempest will store these values in the Resource and relate it to the Project or Import Policy.
+	return &app.OperationResponse{
+		Resource: &app.Resource{
+			DisplayName: fmt.Sprintf("Example Resource - %s", color),
+			Properties: map[string]any{
+				"color": color,
+			},
+			Links: []*app.Link{
+				{
+					URL:   fmt.Sprintf("https://example.com/resource/%s", req.Resource.ExternalID),
+					Title: "Example.com Resource Console",
+					Type:  app.LinkTypeExternal,
+				},
+			},
+		},
+	}, nil
+}
+
+// The delete function should perform the operations necessary to delete the resource in the external system.
+func deleteFn(ctx context.Context, req *app.OperationRequest) (*app.OperationResponse, error) {
+	// The incoming request will contain the ExternalID of the resource that needs to be deleted in the req.Resource object,
+	// the environment variables and secrets that are configured for the Project, as well as Metadata about the Project.
+	//
+	// For a Delete operation, the req.Resource object will also be populated with the current state of the resource in Tempest.
+	// This includes the ExternalID, DisplayName, and Properties.
+
+	// ... perform some operation to delete the resource from the external system ...
+	// err := client.Delete(ctx, req.Resource.ExternalID)
+
+	// Construct the OperationResponse which contains the Resource that was deleted.
+	return &app.OperationResponse{
+		Resource: &app.Resource{
+			ExternalID: req.Resource.ExternalID,
+		},
+	}, nil
+}
+
+// The list function should perform the operations necessary to list all resources of this type in the external system.
+func listFn(ctx context.Context, req *app.ListRequest) (*app.ListResponse, error) {
+	// The ListRequest includes Metadata about the Project.
+	// It also includes a special "Next" field that can be used to paginate the results.
+	// Tempest will set the "Next" field to "" when it is the first call.
+
+	// ... perform some operation to list all resources of this type in the external system ...
+	// resources, err := client.List(ctx)
+	resource1 := &app.Resource{
+		ExternalID:  "1234567890",
+		DisplayName: "Example Resource - Blue",
+		Properties: map[string]any{
+			"color": "blue",
+		},
+	}
+	resource2 := &app.Resource{
+		ExternalID:  "0987654321",
+		DisplayName: "Example Resource - Red",
+		Properties: map[string]any{
+			"color": "red",
+		},
+	}
+
+	// Construct the ListResponse which contains a list of Resources in the external system.
+	return &app.ListResponse{
+		Resources: []*app.Resource{
+			resource1,
+			resource2,
+		},
+		// Optionally, set the "Next" field to a value that can be used to paginate the results.
+		Next: "2",
+	}, nil
+}
+
+var (
+	//go:embed instructions.md
+	instructions string
+
+	//go:embed schema/properties.json
+	properties []byte
+
+	//go:embed schema/input.json
+	input []byte
+)
+
+// App is the main function that is called by the Tempest SDK and returns the app object.
+// The name of the function must be 'App' and it must return an *app.App object.
+func App() *app.App {
+	// The ResourceDefinition is the main object that defines the resource as part of the app.
+	// An App can have multiple ResourceDefinitions configured, but the 'Type' must be unique.
+	exampleDef := app.ResourceDefinition{
+		// Type is the internal identifier for the resource type, and must be unique within the app.
+		Type: "example",
+		// Description is a short description of the resource type that will be displayed in the Tempest UI.
+		Description: "And example resource for the Hello World app.",
+		// DisplayName is the name of the resource type that will be displayed in the Tempest UI.
+		DisplayName: "Example Resource",
+		// The LifecycleStage is the stage of the resource in the Developer Lifecycle.
+		// The options, in order, are:
+		// LifecycleStageCode
+		// LifecycleStageBuild
+		// LifecycleStageTest
+		// LifecycleStageRelease
+		// LifecycleStageDeploy
+		// LifecycleStageOperate
+		// LifecycleStageMonitor
+		LifecycleStage: app.LifecycleStageCode,
+		// The PropertiesSchema is the JSON schema that defines the properties of the individual resource.
+		// After every Create, Update, Read, or List operation, the properties returned by the function
+		// will be validated against this schema.
+		// The properties in this schema can be used as input to other recipe steps in the UI.
+		//
+		// This example schema defines one property, 'name', which is a string.
+		PropertiesSchema: app.MustParseJSONSchema(app.GenericEmptySchema),
+		// Links are a list of links that will be displayed in the UI for the resource type.
+		// These links should be relevant to the resource type and provide additional information or actions.
+		// Individual resources can also have links that are specific to that resource.
+		//
+		// There are different types of links that can be displayed:
+		// - Support: The link to the support page for the resource type.
+		// - Documentation: The link to the documentation for the resource type.
+		// - Administration: The link to the administration page for the resource type.
+		Links: []app.Link{
+			{
+				URL:   "http://example.com",
+				Title: "Example Link",
+				Type:  app.LinkTypeDocumentation,
+			},
+		},
+		// InstructionsMarkdown is the markdown content that will be displayed in the UI for the resource type.
+		// This can include instructions on how to use the resource, best practices, or other helpful information.
+		InstructionsMarkdown: instructions,
+	}
+
+	// Assign a function for each of the CRUD operations.
+
+	// Create is called when Tempest is instructed to create a new resource in the external system.
+	//
+	// Create includes a schema that defines the shape of the input.
+	// The Tempest UI will display these inputs to the user when creating or updating a resource as part of a Recipe.
+	// That input will be validated against the schema before the function is called.
+	exampleDef.CreateFn(
+		// The function handler that will be run when the Create operation is called.
+		createFn,
+		// The schema that defines the input for the Create operation. This schema is empty, but can be extended to suit your needs.
+		app.MustParseJSONSchema(app.GenericEmptySchema),
+	)
+
+	// Update is called when Tempest is instructed to update an existing resource in the external system.
+	// This process can happen as part of a Deployment in a Project.
+	//
+	// Update includes a schema that defines the shape of the input.
+	// The Tempest UI will display these inputs to the user when creating or updating a resource as part of a Recipe.
+	// That input will be validated against the schema before the function is called.
+	exampleDef.UpdateFn(
+		// The function handler that will be run when the Update operation is called.
+		updateFn,
+		// The schema that defines the input for the Update operation. This schema is empty, but can be extended to suit your needs.
+		app.MustParseJSONSchema(app.GenericEmptySchema),
+	)
+
+	// Read and Delete functions are also assigned to the resource definition.
+	// There is no input schema for these functions, as they do not take input from the user.
+	// Environment Variables and Secrets can still be accessed from these functions, however.
+
+	// Read is called when Tempest needs to sync the state of the resource with the external system.
+	exampleDef.ReadFn(readFn)
+	// Delete is called when Tempest is instructed to delete the resource from the external system.
+	exampleDef.DeleteFn(deleteFn)
+
+	// List is called when Tempest needs to list all resources of this type in the external system.
+	// This process happens as part of a Resource Import Policy.
+	exampleDef.ListFn(listFn)
+
+	// Add a healthcheck function to the resource definition.
+	// This will allow Tempest to monitor and display the health of the resource provider.
+	// The function in this case is fairly simple, as it just returns a healthy status.
+	// More complex health checks can be implemented as needed, such as checking the status of the external system.
+	exampleDef.HealthCheckFn(func(ctx context.Context) (*app.HealthCheckResponse, error) {
+		return &app.HealthCheckResponse{
+			Status: app.HealthCheckStatusHealthy,
+		}, nil
+	})
+
+	// Finally, add the resource definition(s) to the app and return the configured App object.
+	return app.New(
+		app.WithResourceDefinition(exampleDef),
+	)
+}

--- a/apps/helloworld/v1/instructions.md
+++ b/apps/helloworld/v1/instructions.md
@@ -1,0 +1,7 @@
+# Example Resource
+
+This resource creates an Example Resource with a specified color.
+
+## Setup Instructions
+
+1. Confirm access to the Example system...

--- a/apps/helloworld/v1/schema/input.json
+++ b/apps/helloworld/v1/schema/input.json
@@ -1,0 +1,19 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+        "color": {
+            "title": "Color",
+            "description": "The color of the resource.",
+            "type": "string",
+            "enum": [
+                "red",
+                "green",
+                "blue"
+            ],
+            "default": "red"
+        }
+    },
+    "required": [],
+    "additionalProperties": false
+}

--- a/apps/helloworld/v1/schema/input.json
+++ b/apps/helloworld/v1/schema/input.json
@@ -6,11 +6,6 @@
             "title": "Color",
             "description": "The color of the resource.",
             "type": "string",
-            "enum": [
-                "red",
-                "green",
-                "blue"
-            ],
             "default": "red"
         }
     },

--- a/apps/helloworld/v1/schema/properties.json
+++ b/apps/helloworld/v1/schema/properties.json
@@ -1,0 +1,15 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+        "color": {
+            "title": "Color",
+            "description": "The color of the resource.",
+            "type": "string"
+        }
+    },
+    "required": [
+        "color"
+    ],
+    "additionalProperties": false
+}

--- a/apps/opentofu/v1/app.go
+++ b/apps/opentofu/v1/app.go
@@ -299,7 +299,7 @@ func App() *app.App {
 		// LifecycleStageMonitor
 		LifecycleStage: app.LifecycleStageOperate,
 		// The PropertiesSchema is the JSON schema that defines the properties of the individual resource.
-		// After every Create, Update, Delete, Read, or List operation, the properties returned by the function
+		// After every Create, Update, Read, or List operation, the properties returned by the function
 		// will be validated against this schema.
 		// The properties in this schema can be used as input to other recipe steps in the UI.
 		PropertiesSchema: app.MustParseJSONSchema(propertiesSchema),
@@ -320,8 +320,9 @@ func App() *app.App {
 
 	// Assign a function for each of the CRUD operations, starting with Create and Update.
 	// Create and Update also include a schema that defines the shape of the input.
-	// The Tempest UI will also display these inputs to the user when creating or updating a resource as part of a Recipe.
+	// The Tempest UI will display these inputs to the user when creating or updating a resource as part of a Recipe.
 	// That input will be validated against the schema before the function is called.
+
 	// Create is called when Tempest is instructed to create a new resource in the external system.
 	bucketDef.CreateFn(
 		createFn,

--- a/apps/opentofu/v1/app.go
+++ b/apps/opentofu/v1/app.go
@@ -2,10 +2,10 @@ package opentofu
 
 import (
 	"context"
-	_ "embed"
+	"embed"
 	"fmt"
+	"io/fs"
 	"log"
-	"os"
 	"os/exec"
 
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
@@ -15,35 +15,137 @@ import (
 
 const consoleURLTemplate = "https://%s.console.aws.amazon.com/s3/buckets/%s"
 
-var (
-	tfPath  string
-	workDir string
-)
+//go:embed module/*.tf
+var moduleFS embed.FS
 
-func init() {
-	var err error
-	tfPath, err = exec.LookPath("tofu")
+// setupTofu is a helper function that creates a new OpenTofu runner.
+// It first pulls the 'secret_key' and 'access_key' from the Tempest Environment Variables.
+// It then creates a new OpenTofu runner with the path to the tofu binary, the module filesystem, and the environment variables.
+func setupTofu(env map[string]app.EnvironmentVariable) (*opentofu.Runner, error) {
+	secretKey, ok := env["secret_key"]
+	if !ok {
+		return nil, fmt.Errorf("secret_key not found in environment")
+	}
+
+	accessKey, ok := env["access_key"]
+	if !ok {
+		return nil, fmt.Errorf("access_key not found in environment")
+	}
+
+	e := map[string]string{
+		"AWS_ACCESS_KEY_ID":     accessKey.Value,
+		"AWS_SECRET_ACCESS_KEY": secretKey.Value,
+	}
+
+	tfPath, err := exec.LookPath("tofu")
 	if err != nil {
 		log.Fatalf("Failed to find tofu binary: %s", err)
 	}
 
-	workDir = os.Getenv("OPENTOFU_WORKDIR")
-	if workDir == "" {
-		log.Fatal("OPENTOFU_WORKDIR is not set")
+	module, err := fs.Sub(moduleFS, "module")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get module sub filesystem: %w", err)
 	}
-}
 
-func applyFn(ctx context.Context, req *app.OperationRequest) (*app.OperationResponse, error) {
-	tofu, err := opentofu.New(tfPath, workDir)
+	tofu, err := opentofu.New(tfPath, module, e)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create OpenTofu runner: %w", err)
 	}
 
+	return tofu, nil
+}
+
+func createFn(ctx context.Context, req *app.OperationRequest) (*app.OperationResponse, error) {
+	// Create a new OpenTofu runner for this operation.
+	tofu, err := setupTofu(req.Environment)
+	if err != nil {
+		return nil, err
+	}
+
+	// Run the `opentofu apply` command with the input map used as variables.
 	state, err := tofu.Apply(req.Input)
 	if err != nil {
 		return nil, fmt.Errorf("failed to apply OpenTofu module: %w", err)
 	}
 
+	// Create a new properties map with the properties from the state.
+	// These properties should match with the `properties.json` schema.
+	// This object will be returned to the Tempest API and the properties will be displayed in the UI.
+	properties := make(map[string]any)
+	for _, r := range state.Values.RootModule.Resources {
+		switch {
+		case r.Type == "aws_s3_bucket" && r.Values["bucket"] == req.Input["name"]:
+			properties["arn"] = r.Values["arn"]
+			properties["bucket"] = r.Values["bucket"]
+			properties["region"] = r.Values["region"]
+		case r.Type == "aws_s3_bucket_versioning" && r.Values["bucket"] == req.Input["name"]:
+			vconfs := r.Values["versioning_configuration"].([]any)
+			if len(vconfs) == 1 {
+				properties["versioning"] = vconfs[0].(map[string]any)["status"]
+			}
+		}
+	}
+
+	// Construct the OperationResponse which includes the Resource that was operated on.
+	return &app.OperationResponse{
+		Resource: &app.Resource{
+			// ExternalID is the unique identifier for the resource in the external system.
+			// This is used to identify the resource in subsequent operations.
+			ExternalID: properties["arn"].(string),
+			// DisplayName is the name of the resource that will be displayed in the UI.
+			DisplayName: properties["bucket"].(string),
+			// Properties is a map of key-value pairs that represent the properties of the resource.
+			Properties: properties,
+			// Links is a list of links that will be displayed in the UI.
+			// There are different types of links that can be displayed:
+			// - External: The link to view the resource in the external system.
+			// - Support: The link to the support page for the individual resource.
+			// - Endpoint: The link to the endpoint of the resource. For example, the connection string for a database.
+			// - Documentation: The link to the documentation for the resource.
+			// - Administration: The link to the administration page for the resource.
+			Links: []*app.Link{
+				{
+					URL:   fmt.Sprintf(consoleURLTemplate, properties["region"], properties["bucket"]),
+					Title: "AWS Console",
+					Type:  app.LinkTypeExternal,
+				},
+			},
+		},
+	}, nil
+}
+
+func updateFn(ctx context.Context, req *app.OperationRequest) (*app.OperationResponse, error) {
+	// The ExternalID is the unique identifier for the resource in the external system.
+	// In this case, it's an ARN, but we only need the Resource part.
+	a, err := arn.Parse(req.Resource.ExternalID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create a new OpenTofu runner for this operation.
+	tofu, err := setupTofu(req.Environment)
+	if err != nil {
+		return nil, err
+	}
+
+	// First, import the existing resource into the fresh state.
+	err = tofu.Import(req.Input, map[string]string{
+		"aws_s3_bucket.bucket":                a.Resource,
+		"aws_s3_bucket_versioning.versioning": a.Resource,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to import OpenTofu module: %w", err)
+	}
+
+	// Run the `opentofu apply` command with the new input.
+	state, err := tofu.Apply(req.Input)
+	if err != nil {
+		return nil, fmt.Errorf("failed to apply OpenTofu module: %w", err)
+	}
+
+	// Create a new properties map with the properties from the state.
+	// These properties should match with the `properties.json` schema.
+	// This object will be returned to the Tempest API and the properties will be displayed in the UI.
 	properties := make(map[string]any)
 	for _, r := range state.Values.RootModule.Resources {
 		switch {
@@ -61,49 +163,34 @@ func applyFn(ctx context.Context, req *app.OperationRequest) (*app.OperationResp
 
 	return &app.OperationResponse{
 		Resource: &app.Resource{
-			ExternalID:  properties["arn"].(string),
-			DisplayName: properties["bucket"].(string),
-			Properties:  properties,
-			Links: []*app.Link{
-				{
-					URL:   fmt.Sprintf(consoleURLTemplate, properties["region"], properties["bucket"]),
-					Title: "AWS Console",
-					Type:  app.LinkTypeExternal,
-				},
-			},
+			// In this case the ExternalID did not change so it is omitted.
+			// The DisplayName also did not change, so it is omitted.
+			// The Properties are updated with the new values.
+			Properties: properties,
 		},
 	}, nil
 }
 
-func deleteFn(ctx context.Context, req *app.OperationRequest) (*app.OperationResponse, error) {
+// readFn is called when Tempest needs to sync the state of the resource with the external system.
+func readFn(ctx context.Context, req *app.OperationRequest) (*app.OperationResponse, error) {
 	a, err := arn.Parse(req.Resource.ExternalID)
 	if err != nil {
 		return nil, err
 	}
 
-	tofu, err := opentofu.New(tfPath, workDir)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create OpenTofu runner: %w", err)
-	}
-
-	err = tofu.Destroy(map[string]any{
-		"name": a.Resource,
-	})
+	// Create a new OpenTofu runner for this operation.
+	tofu, err := setupTofu(req.Environment)
 	if err != nil {
 		return nil, err
 	}
 
-	return &app.OperationResponse{
-		Resource: &app.Resource{
-			ExternalID: req.Resource.ExternalID,
-		},
-	}, nil
-}
-
-func readFn(ctx context.Context, req *app.OperationRequest) (*app.OperationResponse, error) {
-	tofu, err := opentofu.New(tfPath, workDir)
+	// First, import the existing resource into the fresh state.
+	err = tofu.Import(req.Input, map[string]string{
+		"aws_s3_bucket.bucket":                a.Resource,
+		"aws_s3_bucket_versioning.versioning": a.Resource,
+	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to create OpenTofu runner: %w", err)
+		return nil, fmt.Errorf("failed to import OpenTofu module: %w", err)
 	}
 
 	state, err := tofu.Show()
@@ -132,7 +219,6 @@ func readFn(ctx context.Context, req *app.OperationRequest) (*app.OperationRespo
 
 	return &app.OperationResponse{
 		Resource: &app.Resource{
-			ExternalID:  properties["arn"].(string),
 			DisplayName: properties["bucket"].(string),
 			Properties:  properties,
 			Links: []*app.Link{
@@ -146,63 +232,36 @@ func readFn(ctx context.Context, req *app.OperationRequest) (*app.OperationRespo
 	}, nil
 }
 
-func listFn(ctx context.Context, req *app.ListRequest) (*app.ListResponse, error) {
-	tofu, err := opentofu.New(tfPath, workDir)
+func deleteFn(ctx context.Context, req *app.OperationRequest) (*app.OperationResponse, error) {
+	a, err := arn.Parse(req.Resource.ExternalID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create OpenTofu runner: %w", err)
+		return nil, err
 	}
 
-	buckets, err := tofu.List("aws_s3_bucket")
+	tofu, err := setupTofu(req.Environment)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list OpenTofu resources: %w", err)
+		return nil, err
 	}
 
-	versionings, err := tofu.List("aws_s3_bucket_versioning")
+	err = tofu.Import(nil, map[string]string{
+		"aws_s3_bucket.bucket":                a.Resource,
+		"aws_s3_bucket_versioning.versioning": a.Resource,
+	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to list OpenTofu resources: %w", err)
+		return nil, fmt.Errorf("failed to import OpenTofu module: %w", err)
 	}
 
-	resources := make([]*app.Resource, 0, len(buckets))
-	for _, bucket := range buckets {
-		properties := make(map[string]any)
-		if bucket.Type == "aws_s3_bucket" {
-			properties["arn"] = bucket.Values["arn"]
-			properties["bucket"] = bucket.Values["bucket"]
-			properties["region"] = bucket.Values["region"]
-		}
-
-		// Attach the versioning config to the bucket if it exists
-		for _, versioning := range versionings {
-			if versioning.Values["bucket"] == bucket.Values["bucket"] {
-				vconfs := versioning.Values["versioning_configuration"].([]any)
-				if len(vconfs) == 1 {
-					properties["versioning"] = vconfs[0].(map[string]any)["status"]
-				}
-			}
-		}
-
-		resources = append(resources, &app.Resource{
-			ExternalID:  bucket.Values["arn"].(string),
-			DisplayName: bucket.Values["bucket"].(string),
-			Properties:  bucket.Values,
-			Links: []*app.Link{
-				{
-					URL:   fmt.Sprintf(consoleURLTemplate, bucket.Values["region"], bucket.Values["bucket"]),
-					Title: "AWS Console",
-					Type:  app.LinkTypeExternal,
-				},
-			},
-		})
+	err = tofu.Destroy()
+	if err != nil {
+		return nil, err
 	}
 
-	return &app.ListResponse{
-		Resources: resources,
-	}, nil
-}
-
-func healthFn(ctx context.Context) (*app.HealthCheckResponse, error) {
-	return &app.HealthCheckResponse{
-		Status: app.HealthCheckStatusHealthy,
+	// Construct the OperationResponse which includes the Resource that was deleted.
+	// The Delete Operation should return the ExternalID of the resource that was deleted.
+	return &app.OperationResponse{
+		Resource: &app.Resource{
+			ExternalID: req.Resource.ExternalID,
+		},
 	}, nil
 }
 
@@ -212,38 +271,90 @@ var (
 
 	//go:embed schema/apply.json
 	applySchema []byte
+
+	//go:embed instructions.md
+	instructions string
 )
 
+// App is the main function that is called by the Tempest SDK and returns the app object.
+// The name of the function must be 'App' and it must return an *app.App object.
 func App() *app.App {
-	resourceDefinition := app.ResourceDefinition{
-		Type:             "s3_bucket",
-		Description:      "An example resource that creates an AWS S3 Bucket by executing an OpenTofu module.",
-		DisplayName:      "S3 Bucket",
-		LifecycleStage:   app.LifecycleStageOperate,
+	// The ResourceDefinition is the main object that defines the resource as part of the app.
+	// An App can have multiple ResourceDefinitions configured, but the 'Type' must be unique.
+	bucketDef := app.ResourceDefinition{
+		// Type is the internal identifier for the resource type, and must be unique within the app.
+		Type: "s3_bucket",
+		// Description is a short description of the resource type that will be displayed in the Tempest UI.
+		Description: "An example resource that creates an AWS S3 Bucket by executing an OpenTofu module.",
+		// DisplayName is the name of the resource type that will be displayed in the Tempest UI.
+		DisplayName: "S3 Bucket",
+		// The LifecycleStage is the stage of the resource in the Developer Lifecycle.
+		// The options, in order, are:
+		// LifecycleStageCode
+		// LifecycleStageBuild
+		// LifecycleStageTest
+		// LifecycleStageRelease
+		// LifecycleStageDeploy
+		// LifecycleStageOperate
+		// LifecycleStageMonitor
+		LifecycleStage: app.LifecycleStageOperate,
+		// The PropertiesSchema is the JSON schema that defines the properties of the individual resource.
+		// After every Create, Update, Delete, Read, or List operation, the properties returned by the function
+		// will be validated against this schema.
+		// The properties in this schema can be used as input to other recipe steps in the UI.
 		PropertiesSchema: app.MustParseJSONSchema(propertiesSchema),
+		// Links are a list of links that will be displayed in the UI for the resource type.
+		// These links should be relevant to the resource type and provide additional information or actions.
+		// Individual resources can also have links that are specific to that resource.
+		Links: []app.Link{
+			{
+				URL:   "https://docs.aws.amazon.com/AmazonS3/latest/userguide/Welcome.html",
+				Title: "AWS S3 Documentation",
+				Type:  app.LinkTypeDocumentation,
+			},
+		},
+		// InstructionsMarkdown is the markdown content that will be displayed in the UI for the resource type.
+		// This can include instructions on how to use the resource, best practices, or other helpful information.
+		InstructionsMarkdown: instructions,
 	}
 
-	// Add various operations to the resource definition.
-	resourceDefinition.CreateFn(
-		applyFn,
+	// Assign a function for each of the CRUD operations, starting with Create and Update.
+	// Create and Update also include a schema that defines the shape of the input.
+	// The Tempest UI will also display these inputs to the user when creating or updating a resource as part of a Recipe.
+	// That input will be validated against the schema before the function is called.
+	// Create is called when Tempest is instructed to create a new resource in the external system.
+	bucketDef.CreateFn(
+		createFn,
 		app.MustParseJSONSchema(applySchema),
 	)
 
-	resourceDefinition.UpdateFn(
-		applyFn,
+	// Update is called when Tempest is instructed to update the resource.
+	// This can happen as part of a new Deployment in the Tempest Project.
+	bucketDef.UpdateFn(
+		updateFn,
 		app.MustParseJSONSchema(applySchema),
 	)
 
-	resourceDefinition.ReadFn(readFn)
-	resourceDefinition.DeleteFn(deleteFn)
-	resourceDefinition.ListFn(listFn)
+	// Read and Delete functions are also assigned to the resource definition.
+	// There is no input schema for these functions, as they do not take input from the user.
+	// Environment Variables and Secrets can still be accessed from these functions, however.
+	// Read is called when Tempest needs to sync the state of the resource with the external system.
+	bucketDef.ReadFn(readFn)
+	// Delete is called when Tempest is instructed to delete the resource from the external system.
+	bucketDef.DeleteFn(deleteFn)
 
 	// Add a healthcheck function to the resource definition.
 	// This will allow Tempest to monitor and display the health of the resource provider.
-	resourceDefinition.HealthCheckFn(healthFn)
+	// The function in this case is fairly simple, as it just returns a healthy status.
+	// More complex health checks can be implemented as needed, such as checking the status of the external system.
+	bucketDef.HealthCheckFn(func(ctx context.Context) (*app.HealthCheckResponse, error) {
+		return &app.HealthCheckResponse{
+			Status: app.HealthCheckStatusHealthy,
+		}, nil
+	})
 
-	// Add the resource definition to the app.
+	// Finally, add the resource definition to the app and return the configured App object.
 	return app.New(
-		app.WithResourceDefinition(resourceDefinition),
+		app.WithResourceDefinition(bucketDef),
 	)
 }

--- a/apps/opentofu/v1/app.go
+++ b/apps/opentofu/v1/app.go
@@ -19,15 +19,15 @@ const consoleURLTemplate = "https://%s.console.aws.amazon.com/s3/buckets/%s"
 var moduleFS embed.FS
 
 // setupTofu is a helper function that creates a new OpenTofu runner.
-// It first pulls the 'secret_key' and 'access_key' from the Tempest Environment Variables.
+// It first pulls the 'SECRET_KEY' and 'ACCESS_KEY' from the Tempest Environment Variables.
 // It then creates a new OpenTofu runner with the path to the tofu binary, the module filesystem, and the environment variables.
 func setupTofu(env map[string]app.EnvironmentVariable) (*opentofu.Runner, error) {
-	secretKey, ok := env["secret_key"]
+	secretKey, ok := env["SECRET_KEY"]
 	if !ok {
 		return nil, fmt.Errorf("secret_key not found in environment")
 	}
 
-	accessKey, ok := env["access_key"]
+	accessKey, ok := env["ACCESS_KEY"]
 	if !ok {
 		return nil, fmt.Errorf("access_key not found in environment")
 	}

--- a/apps/opentofu/v1/instructions.md
+++ b/apps/opentofu/v1/instructions.md
@@ -1,0 +1,7 @@
+# S3 Bucket
+
+This resource creates an AWS S3 Bucket by executing an OpenTofu module.
+
+## Setup Instructions
+
+1. Configure the `access_key` and `secret_key` secrets in your Tempest Project.

--- a/apps/opentofu/v1/module/variables.tf
+++ b/apps/opentofu/v1/module/variables.tf
@@ -7,6 +7,7 @@ variable "region" {
 variable "name" {
   description = "The name of the S3 bucket"
   type        = string
+  default     = null
 }
 
 variable "versioning" {

--- a/deps/opentofu/commands.go
+++ b/deps/opentofu/commands.go
@@ -7,40 +7,55 @@ import (
 	"os/exec"
 )
 
-func (tf *Runner) init() error {
-	cmd := exec.Command(tf.openTofuBinary, "init", "-json", "-no-color")
+func (tf *Runner) initCmd() error {
+	cmd := exec.Command(tf.openTofuBinary, "init", "-no-color")
 	cmd.Dir = tf.workDir
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout
+	cmd.Env = tf.environment
 
 	return cmd.Run()
 }
 
-func (tf *Runner) apply(variables []string) error {
-	args := []string{"apply", "-no-color", "-auto-approve", "-input=false", "-json"}
+func (tf *Runner) applyCmd(variables []string) error {
+	args := []string{"apply", "-no-color", "-auto-approve", "-input=false"}
 	args = append(args, variables...)
 
 	cmd := exec.Command(tf.openTofuBinary, args...)
 	cmd.Dir = tf.workDir
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout
+	cmd.Env = tf.environment
 
 	return cmd.Run()
 }
 
-func (tf *Runner) destroy(variables []string) error {
-	args := []string{"destroy", "-no-color", "-auto-approve", "-input=false", "-refresh=false", "-json"}
+func (tf *Runner) importCmd(variables []string, resourceID, externalID string) error {
+	args := []string{"import", "-no-color", "-input=false", resourceID, externalID}
 	args = append(args, variables...)
 
 	cmd := exec.Command(tf.openTofuBinary, args...)
 	cmd.Dir = tf.workDir
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout
+	cmd.Env = tf.environment
 
 	return cmd.Run()
 }
 
-func (tf *Runner) show() (*State, error) {
+func (tf *Runner) destroyCmd() error {
+	args := []string{"destroy", "-no-color", "-auto-approve", "-input=false", "-refresh=false"}
+
+	cmd := exec.Command(tf.openTofuBinary, args...)
+	cmd.Dir = tf.workDir
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = os.Stdout
+	cmd.Env = tf.environment
+
+	return cmd.Run()
+}
+
+func (tf *Runner) showCmd() (*State, error) {
 	out := new(bytes.Buffer)
 
 	args := []string{"show", "-json", "-no-color"}
@@ -48,6 +63,7 @@ func (tf *Runner) show() (*State, error) {
 	cmd.Dir = tf.workDir
 	cmd.Stdout = out
 	cmd.Stderr = os.Stderr
+	cmd.Env = tf.environment
 
 	if err := cmd.Run(); err != nil {
 		return nil, err

--- a/deps/opentofu/operations.go
+++ b/deps/opentofu/operations.go
@@ -4,8 +4,11 @@ import (
 	"fmt"
 )
 
+// Apply runs "opentofu apply" with the given input variables.
+// The returned state is a parsed version of the JSON output from "opentofu show".
+// This output contains the properties and values of the resource(s) created by the module.
 func (tf *Runner) Apply(input map[string]any) (*State, error) {
-	if err := tf.init(); err != nil {
+	if err := tf.initCmd(); err != nil {
 		return nil, fmt.Errorf("opentofu init: %w", err)
 	}
 
@@ -15,20 +18,24 @@ func (tf *Runner) Apply(input map[string]any) (*State, error) {
 		variables = append(variables, arg...)
 	}
 
-	if err := tf.apply(variables); err != nil {
+	if err := tf.applyCmd(variables); err != nil {
 		return nil, fmt.Errorf("opentofu apply: %w", err)
 	}
 
-	res, err := tf.show()
+	state, err := tf.showCmd()
 	if err != nil {
 		return nil, fmt.Errorf("opentofu show: %w", err)
 	}
 
-	return res, nil
+	return state, nil
 }
 
-func (tf *Runner) Destroy(input map[string]any) error {
-	if err := tf.init(); err != nil {
+// Import will run "opentofu import" for each resource ID in the given map.
+// The map associates resource IDs to their external IDs.
+// This is only needed if running OpenTofu in a "stateless" mode.
+// If you're using remote state, you can ignore this method, and just use Apply.
+func (tf *Runner) Import(input map[string]any, resourceIDsToExternalIDs map[string]string) error {
+	if err := tf.initCmd(); err != nil {
 		return fmt.Errorf("opentofu init: %w", err)
 	}
 
@@ -38,38 +45,36 @@ func (tf *Runner) Destroy(input map[string]any) error {
 		variables = append(variables, arg...)
 	}
 
-	return tf.destroy(variables)
+	for id, externalID := range resourceIDsToExternalIDs {
+		err := tf.importCmd(variables, id, externalID)
+		if err != nil {
+			return fmt.Errorf("opentofu import: %w", err)
+		}
+	}
+
+	return nil
 }
 
+// Destroy runs "opentofu destroy" to remove all resources created by the module.
+func (tf *Runner) Destroy() error {
+	if err := tf.initCmd(); err != nil {
+		return fmt.Errorf("opentofu init: %w", err)
+	}
+
+	return tf.destroyCmd()
+}
+
+// Show runs "opentofu show" and returns the parsed state.
+// This output contains the properties and values of the resource(s) created by the module.
 func (tf *Runner) Show() (*State, error) {
-	if err := tf.init(); err != nil {
+	if err := tf.initCmd(); err != nil {
 		return nil, fmt.Errorf("opentofu init: %w", err)
 	}
 
-	state, err := tf.show()
+	state, err := tf.showCmd()
 	if err != nil {
 		return nil, fmt.Errorf("opentofu show: %w", err)
 	}
 
 	return state, nil
-}
-
-func (tf *Runner) List(t string) ([]*Resource, error) {
-	if err := tf.init(); err != nil {
-		return nil, fmt.Errorf("opentofu init: %w", err)
-	}
-
-	state, err := tf.show()
-	if err != nil {
-		return nil, fmt.Errorf("opentofu show: %w", err)
-	}
-
-	var resources []*Resource
-	for _, r := range state.Values.RootModule.Resources {
-		if r.Type == t {
-			resources = append(resources, &r)
-		}
-	}
-
-	return resources, nil
 }

--- a/tempest.yaml
+++ b/tempest.yaml
@@ -6,4 +6,7 @@ apps:
   opentofu:
     - path: apps/opentofu/v1
       version: v1
+  helloworld:
+    - path: apps/helloworld/v1
+      version: v1
 build_dir: .build

--- a/tempest.yaml
+++ b/tempest.yaml
@@ -3,10 +3,10 @@ apps:
   dashboards:
     - path: apps/dashboards/v1
       version: v1
-  opentofu:
-    - path: apps/opentofu/v1
-      version: v1
   helloworld:
     - path: apps/helloworld/v1
+      version: v1
+  opentofu:
+    - path: apps/opentofu/v1
       version: v1
 build_dir: .build


### PR DESCRIPTION
## Contents

1. Adds new `helloworld` example app with lots of documentation. This example will be used by the CLI in a future PR instead of embedding the example in the CLI binary.
2. Updates `opentofu` example app with documentation and more methods. I also expanded the example so it will work across different projects. This uses a "stateless" approach to operating. I chose to omit the List function as it doesn't really work for OpenTofu unless the provider has a specific datasource to list all of the resources of that type.